### PR TITLE
Add cross-runtime support

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -22,8 +22,6 @@
   },
   "tasks": {
     "test": "deno test -A",
-    "generate": "deno run -Ar https://deno.land/x/generate/cli/main.ts gen.ts",
-    "docs": "deno run -A --unstable-kv docs/main.ts"
-  },
-  "exclude": ["./docs/static"]
+    "generate": "deno run -Ar https://deno.land/x/generate/cli/main.ts gen.ts"
+  }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -12,8 +12,8 @@
     "jsxImportSource": "jsonx-jsx"
   },
   "imports": {
+    "@cross/deepmerge": "jsr:@cross/deepmerge@^1.0.0",
     "@std/assert": "jsr:@std/assert@^0.220.1",
-    "@std/collections": "jsr:@std/collections@^0.220.1",
     "@std/encoding": "jsr:@std/encoding@^0.220.1",
     "@std/fs": "jsr:@std/fs@^0.220.1",
     "@std/path": "jsr:@std/path@^0.220.1",

--- a/lib/std/local_assets/components.tsx
+++ b/lib/std/local_assets/components.tsx
@@ -2,6 +2,7 @@ import type { ExpandGlobOptions } from "@std/fs";
 import { expandGlobSync } from "@std/fs";
 import { encodeBase64 } from "@std/encoding/base64";
 import { normalize } from "@std/path";
+import { readFileSync } from "node:fs";
 import type { AssetsData } from "jsonx/std/assets/mod.ts";
 import { Asset, AssetKind, EncodingType } from "jsonx/std/assets/mod.ts";
 
@@ -14,8 +15,7 @@ export interface LocalAssetProps {
 }
 
 function getLocalAssetContentBase64(src: string | URL) {
-  const bytes = Deno.readFileSync(src);
-  return encodeBase64(bytes);
+  return encodeBase64(readFileSync(src));
 }
 
 /**

--- a/lib/std/runtime/runtime.ts
+++ b/lib/std/runtime/runtime.ts
@@ -1,4 +1,4 @@
-import { deepMerge } from "@std/collections/deep_merge";
+import { deepMerge } from "@cross/deepmerge";
 
 /**
  * JSX is the JSX namespace.


### PR DESCRIPTION
### Changes

- Use cross-runtime `deepMerge`.
- Use cross-runtime `readFileSync`.

Fixes #20.